### PR TITLE
Feature/panstar sdk update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
         <keycloak.version>25.0.0</keycloak.version>
 
-        <panstar-sdk.version>4.0.2</panstar-sdk.version>
+        <panstar-sdk.version>4.1.0</panstar-sdk.version>
         <fmt-maven.version>2.22.1</fmt-maven.version>
         <identification-report.version>1.0.1</identification-report.version>
         <nimbus-jose-jwt.version>9.37.3</nimbus-jose-jwt.version>

--- a/src/main/java/de/l21s/keycloak/eid/EidIdentityBrokerState.java
+++ b/src/main/java/de/l21s/keycloak/eid/EidIdentityBrokerState.java
@@ -11,12 +11,12 @@ public class EidIdentityBrokerState {
 
   private final String clientId;
   private final String tabId;
-  private final String encoded;
+  private final String compositeState;
 
-  private EidIdentityBrokerState(String clientId, String tabId, String encoded) {
+  private EidIdentityBrokerState(String clientId, String tabId, String compositeState) {
     this.clientId = clientId;
     this.tabId = tabId;
-    this.encoded = encoded;
+    this.compositeState = compositeState;
   }
 
   public static EidIdentityBrokerState fromState(String state) {
@@ -34,8 +34,8 @@ public class EidIdentityBrokerState {
     UUID clientDbUuid = new UUID(first, second);
     String clientIdInDb = clientDbUuid.toString();
 
-    String encodedState = tabId + "." + clientIdInDb;
-    return new EidIdentityBrokerState(clientIdInDb, tabId, encodedState);
+    String compositeState = tabId + "." + clientIdInDb;
+    return new EidIdentityBrokerState(clientIdInDb, tabId, compositeState);
   }
 
   public static EidIdentityBrokerState fromRelayState(String relayState) {
@@ -46,8 +46,8 @@ public class EidIdentityBrokerState {
     String tabId = parts[0];
     String clientId = parts[1];
 
-    String encodedState = tabId + "." + clientId;
-    return new EidIdentityBrokerState(clientId, tabId, encodedState);
+    String compositeState = tabId + "." + clientId;
+    return new EidIdentityBrokerState(clientId, tabId, compositeState);
   }
 
   public String getClientId() {
@@ -58,7 +58,7 @@ public class EidIdentityBrokerState {
     return tabId;
   }
 
-  public String getEncoded() {
-    return encoded;
+  public String getCompositeState() {
+    return compositeState;
   }
 }

--- a/src/main/java/de/l21s/keycloak/eid/EidIdentityBrokerState.java
+++ b/src/main/java/de/l21s/keycloak/eid/EidIdentityBrokerState.java
@@ -26,9 +26,16 @@ public class EidIdentityBrokerState {
     }
     String tabId = parts[1];
     String encodedClientId = parts[2];
-    String clientIdInDb = getClientDbUuid(encodedClientId);
+
+    byte[] decodedClientId = Base64Url.decode(encodedClientId);
+    ByteBuffer bb = ByteBuffer.wrap(decodedClientId);
+    long first = bb.getLong();
+    long second = bb.getLong();
+    UUID clientDbUuid = new UUID(first, second);
+    String clientIdInDb = clientDbUuid.toString();
+
     String encodedState = tabId + "." + clientIdInDb;
-    return new EidIdentityBrokerState(encodedClientId, tabId, encodedState);
+    return new EidIdentityBrokerState(clientIdInDb, tabId, encodedState);
   }
 
   public static EidIdentityBrokerState fromRelayState(String relayState) {
@@ -38,18 +45,9 @@ public class EidIdentityBrokerState {
     }
     String tabId = parts[0];
     String clientId = parts[1];
-    String clientIdInDb = getClientDbUuid(clientId);
-    String encodedState = tabId + "." + clientIdInDb;
-    return new EidIdentityBrokerState(clientId, tabId, encodedState);
-  }
 
-  private static String getClientDbUuid(String encodedClientId) {
-    byte[] decodedClientId = Base64Url.decode(encodedClientId);
-    ByteBuffer bb = ByteBuffer.wrap(decodedClientId);
-    long first = bb.getLong();
-    long second = bb.getLong();
-    UUID clientDbUuid = new UUID(first, second);
-    return clientDbUuid.toString();
+    String encodedState = tabId + "." + clientId;
+    return new EidIdentityBrokerState(clientId, tabId, encodedState);
   }
 
   public String getClientId() {

--- a/src/main/java/de/l21s/keycloak/eid/EidIdentityBrokerState.java
+++ b/src/main/java/de/l21s/keycloak/eid/EidIdentityBrokerState.java
@@ -1,0 +1,66 @@
+package de.l21s.keycloak.eid;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.keycloak.common.util.Base64Url;
+
+public class EidIdentityBrokerState {
+
+  private static final Pattern DOT = Pattern.compile("\\.");
+
+  private final String clientId;
+  private final String tabId;
+  private final String encoded;
+
+  private EidIdentityBrokerState(String clientId, String tabId, String encoded) {
+    this.clientId = clientId;
+    this.tabId = tabId;
+    this.encoded = encoded;
+  }
+
+  public static EidIdentityBrokerState fromState(String state) {
+    String[] parts = DOT.split(state, 4);
+    if (parts.length < 3) {
+      throw new IllegalArgumentException("Invalid state: " + state);
+    }
+    String tabId = parts[1];
+    String encodedClientId = parts[2];
+    String clientIdInDb = getClientDbUuid(encodedClientId);
+    String encodedState = tabId + "." + clientIdInDb;
+    return new EidIdentityBrokerState(encodedClientId, tabId, encodedState);
+  }
+
+  public static EidIdentityBrokerState fromRelayState(String relayState) {
+    String[] parts = DOT.split(relayState, 2);
+    if (parts.length != 2) {
+      throw new IllegalArgumentException("Invalid RelayState: " + relayState);
+    }
+    String tabId = parts[0];
+    String clientId = parts[1];
+    String clientIdInDb = getClientDbUuid(clientId);
+    String encodedState = tabId + "." + clientIdInDb;
+    return new EidIdentityBrokerState(clientId, tabId, encodedState);
+  }
+
+  private static String getClientDbUuid(String encodedClientId) {
+    byte[] decodedClientId = Base64Url.decode(encodedClientId);
+    ByteBuffer bb = ByteBuffer.wrap(decodedClientId);
+    long first = bb.getLong();
+    long second = bb.getLong();
+    UUID clientDbUuid = new UUID(first, second);
+    return clientDbUuid.toString();
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public String getTabId() {
+    return tabId;
+  }
+
+  public String getEncoded() {
+    return encoded;
+  }
+}

--- a/src/main/java/de/l21s/keycloak/eid/EidIdentityProvider.java
+++ b/src/main/java/de/l21s/keycloak/eid/EidIdentityProvider.java
@@ -40,7 +40,7 @@ public class EidIdentityProvider extends AbstractIdentityProvider<EidIdentityPro
 
     String authSessionId = request.getAuthenticationSession().getParentSession().getId();
     String relayState =
-        EidIdentityBrokerState.fromState(request.getState().getEncoded()).getEncoded();
+        EidIdentityBrokerState.fromState(request.getState().getEncoded()).getCompositeState();
 
     logger.debug("authSessionId is {}", authSessionId);
     logger.debug("RelayState is {}", relayState);

--- a/src/main/java/de/l21s/keycloak/eid/EidIdentityProvider.java
+++ b/src/main/java/de/l21s/keycloak/eid/EidIdentityProvider.java
@@ -39,7 +39,8 @@ public class EidIdentityProvider extends AbstractIdentityProvider<EidIdentityPro
     logger.info("Requested login with eID. Try to generate TcTokenUri and redirect to AusweisApp.");
 
     String authSessionId = request.getAuthenticationSession().getParentSession().getId();
-    String relayState = request.getState().getEncoded();
+    String relayState =
+        EidIdentityBrokerState.fromState(request.getState().getEncoded()).getEncoded();
 
     logger.debug("authSessionId is {}", authSessionId);
     logger.debug("RelayState is {}", relayState);

--- a/src/main/java/de/l21s/keycloak/eid/configuration/EidSamlResponseHandler.java
+++ b/src/main/java/de/l21s/keycloak/eid/configuration/EidSamlResponseHandler.java
@@ -7,6 +7,7 @@ import de.governikus.panstar.sdk.saml.exception.SamlAuthenticationException;
 import de.governikus.panstar.sdk.saml.exception.UnsuccessfulSamlAuthenticationProcessException;
 import de.governikus.panstar.sdk.saml.response.ProcessedSamlResult;
 import de.governikus.panstar.sdk.utils.exception.InvalidInputException;
+import de.l21s.keycloak.eid.EidIdentityBrokerState;
 import de.l21s.keycloak.eid.EidIdentityProvider;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.core.Context;
@@ -15,9 +16,7 @@ import jakarta.ws.rs.core.UriInfo;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
 import org.keycloak.broker.provider.BrokeredIdentityContext;
-import org.keycloak.broker.provider.util.IdentityBrokerState;
 import org.keycloak.events.EventBuilder;
-import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
@@ -85,6 +84,15 @@ public class EidSamlResponseHandler {
     }
   }
 
+  private String getRestrictedIdString(PersonalDataType personalDataType) {
+    if (personalDataType == null
+        || personalDataType.getRestrictedID() == null
+        || ArrayUtils.isEmpty(personalDataType.getRestrictedID().getID())) {
+      return null;
+    }
+    return Hex.encodeHexString(personalDataType.getRestrictedID().getID());
+  }
+
   private AuthenticationSessionModel getAuthSession(
       UriInfo uriInfo, ProcessedSamlResult samlResponse) {
     // we retrieve the root authentication session via the id
@@ -96,18 +104,8 @@ public class EidSamlResponseHandler {
         session.authenticationSessions().getRootAuthenticationSession(realm, authSessionId);
     // then we can retrieve the initiating authSession via the tabId
     String relayState = uriInfo.getQueryParameters().getFirst("RelayState");
-    IdentityBrokerState identityBrokerState = IdentityBrokerState.encoded(relayState, realm);
-    ClientModel client = realm.getClientByClientId(identityBrokerState.getClientId());
-    return rootAuthSession.getAuthenticationSession(client, identityBrokerState.getTabId());
-  }
-
-  private String getRestrictedIdString(PersonalDataType personalDataType) {
-    if (personalDataType == null
-        || personalDataType.getRestrictedID() == null
-        || ArrayUtils.isEmpty(personalDataType.getRestrictedID().getID())) {
-      return null;
-    }
-    return Hex.encodeHexString(personalDataType.getRestrictedID().getID());
+    EidIdentityBrokerState eidState = EidIdentityBrokerState.fromRelayState(relayState);
+    return rootAuthSession.getAuthenticationSession(realm.getClientById(eidState.getClientId()), eidState.getTabId());
   }
 
   private void setUpIdentity(

--- a/src/main/java/de/l21s/keycloak/eid/configuration/EidSamlResponseHandler.java
+++ b/src/main/java/de/l21s/keycloak/eid/configuration/EidSamlResponseHandler.java
@@ -105,7 +105,8 @@ public class EidSamlResponseHandler {
     // then we can retrieve the initiating authSession via the tabId
     String relayState = uriInfo.getQueryParameters().getFirst("RelayState");
     EidIdentityBrokerState eidState = EidIdentityBrokerState.fromRelayState(relayState);
-    return rootAuthSession.getAuthenticationSession(realm.getClientById(eidState.getClientId()), eidState.getTabId());
+    return rootAuthSession.getAuthenticationSession(
+        realm.getClientById(eidState.getClientId()), eidState.getTabId());
   }
 
   private void setUpIdentity(

--- a/src/test/java/de/l21s/keycloak/eid/EidIdentityProviderUnitTest.java
+++ b/src/test/java/de/l21s/keycloak/eid/EidIdentityProviderUnitTest.java
@@ -27,6 +27,9 @@ import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 public class EidIdentityProviderUnitTest {
 
+  private static final String REQUEST_STATE =
+      "AWDYHOhB3Dy1FcD1rrfLh0eRFAC-t_CSd7G3KpHlb0o.erobji-kr7o.xrUVKpHiRA281FOHHr4wVw";
+
   @Test
   void startAuthenticationWithDesktopClient() {
     try {
@@ -51,7 +54,7 @@ public class EidIdentityProviderUnitTest {
       when(authSession.getParentSession()).thenReturn(rootSession);
       when(request.getAuthenticationSession().getParentSession().getId()).thenReturn("sessionId");
       when(request.getState()).thenReturn(identityBrokerState);
-      when(request.getState().getEncoded()).thenReturn("state");
+      when(request.getState().getEncoded()).thenReturn(REQUEST_STATE);
       when(request.getHttpRequest()).thenReturn(httpRequest);
       when(httpRequest.getHttpHeaders()).thenReturn(httpHeaders);
       when(httpHeaders.getRequestHeader("User-Agent"))
@@ -66,7 +69,7 @@ public class EidIdentityProviderUnitTest {
       String expectedLocationHeaderValue =
           "http://127.0.0.1:24727/eID-Client?tcTokenURL="
               + URLEncoder.encode(
-                  "https://localhost:8443/realms/master/tc-token-endpoint/tc-token?RelayState=state&authSessionId=sessionId",
+                  "https://localhost:8443/realms/master/tc-token-endpoint/tc-token?RelayState=erobji-kr7o.c6b5152a-91e2-440d-bcd4-53871ebe3057&authSessionId=sessionId",
                   StandardCharsets.UTF_8);
       assertNotNull(response);
       assertEquals(303, response.getStatus());
@@ -101,7 +104,7 @@ public class EidIdentityProviderUnitTest {
       when(authSession.getParentSession()).thenReturn(rootSession);
       when(request.getAuthenticationSession().getParentSession().getId()).thenReturn("sessionId");
       when(request.getState()).thenReturn(identityBrokerState);
-      when(request.getState().getEncoded()).thenReturn("state");
+      when(request.getState().getEncoded()).thenReturn(REQUEST_STATE);
       when(request.getHttpRequest()).thenReturn(httpRequest);
       when(httpRequest.getHttpHeaders()).thenReturn(httpHeaders);
       when(httpHeaders.getRequestHeader("User-Agent"))
@@ -116,7 +119,7 @@ public class EidIdentityProviderUnitTest {
       String expectedLocationHeaderValue =
           "eid://127.0.0.1:24727/eID-Client?tcTokenURL="
               + URLEncoder.encode(
-                  "https://localhost:8443/realms/master/tc-token-endpoint/tc-token?RelayState=state&authSessionId=sessionId",
+                  "https://localhost:8443/realms/master/tc-token-endpoint/tc-token?RelayState=erobji-kr7o.c6b5152a-91e2-440d-bcd4-53871ebe3057&authSessionId=sessionId",
                   StandardCharsets.UTF_8);
       assertNotNull(response);
       assertEquals(303, response.getStatus());

--- a/src/test/java/de/l21s/keycloak/eid/configuration/EidSamlResponseHandlerUnitTest.java
+++ b/src/test/java/de/l21s/keycloak/eid/configuration/EidSamlResponseHandlerUnitTest.java
@@ -46,9 +46,7 @@ public class EidSamlResponseHandlerUnitTest {
         mock(RootAuthenticationSessionModel.class);
 
     MultivaluedHashMap<String, String> queryParameters = new MultivaluedHashMap<>();
-    queryParameters.put(
-        "RelayState",
-        List.of("AWDYHOhB3Dy1FcD1rrfLh0eRFAC-t_CSd7G3KpHlb0o.erobji-kr7o.xrUVKpHiRA281FOHHr4wVw"));
+    queryParameters.put("RelayState", List.of("erobji-kr7o.xrUVKpHiRA281FOHHr4wVw"));
     queryParameters.put("authSessionId", List.of("7d04d3c0-660e-475b-8679-c84772987d33"));
 
     String workDir = new File("src/test/resources").getAbsolutePath();


### PR DESCRIPTION
In dem SDK Version `4.1.0` darf der `RelayState` Parameter bei der Erstellung des SAML Requests gemäß Spezifikation nur noch maximal 80 Bytes groß sein. Da der komplette OAuth spezifische `state` Parameter als `RelayState` im SAML Request gesetzt wurde, war dieser mehr als 80 Bytes groß. Nach der erfolgreichen Kommunikation mit Panstar werden zum Abrufen der Keycloak Authentication Session aber nur `clientId` und `tabId` gebraucht. Diese sind zusammen unter 80 Bytes lang. Dementsprechend werden nur noch diesen beiden Paramter dem SAML Request übergeben und entsprechend zurückgespielt. 